### PR TITLE
fix: change channel to `/v2/tx_events`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - 2021-02-11
+### Changed
+- Update messagebus channel to `/v2/tx_events` (from `/v2/txns`)
+
 ## [0.17.1] - 2021-02-03
 ### Added
 - Add `create_txn#errors` to easily access errors

--- a/lib/bloom_remit_client.rb
+++ b/lib/bloom_remit_client.rb
@@ -26,7 +26,7 @@ module BloomRemitClient
 
   include APIClientBase::Base.module
 
-  TXN_UPDATES_CHANNEL = "/v2/txns".freeze
+  TXN_UPDATES_CHANNEL = "/v2/tx_events".freeze
 
   with_configuration do
     has :host, classes: String, default: STAGING


### PR DESCRIPTION
The previous channel `/v2/txns` is not used by bloomremit. It uses `/v2/tx_events` instead.