### PR TITLE
fix: Pass `Authorization` header to BloomRemit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Pass `Authorization` header to BloomRemit
+
 ## [0.17.2] - 2021-02-11
 ### Changed
 - Update messagebus channel to `/v2/tx_events` (from `/v2/txns`)

--- a/lib/bloom_remit_client.rb
+++ b/lib/bloom_remit_client.rb
@@ -48,7 +48,7 @@ module BloomRemitClient
 
     MessageBusClientWorker.subscribe(configuration.host, {
       headers: {
-        "HTTP_AUTHORIZATION" => "Basic #{token}"
+        "Authorization" => "Basic #{token}"
       },
       channels: {
         TXN_UPDATES_CHANNEL => { processor: configuration.on_txn_update },

--- a/spec/lib/bloom_remit_client_spec.rb
+++ b/spec/lib/bloom_remit_client_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe BloomRemitClient do
       encoded_string = Base64.strict_encode64("5:sikret")
 
       aggregate_failures do
-        expect(subscription[:headers]["HTTP_AUTHORIZATION"])
+        expect(subscription[:headers]["Authorization"])
           .to eq "Basic #{encoded_string}"
         expect(subscription[:channels][described_class::TXN_UPDATES_CHANNEL]).
           to eq({processor: "Processor"})


### PR DESCRIPTION
Confusion probably arose from looking at the specs of BloomRemit. The API docs should be followed instead as they specify `Authorization`.