### PR TITLE
feat: read messagebus logs from the start on boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Pass `message_id` of 0 so it reads logs from the start on boot
+
 ## [0.17.3] - 2021-02-19
 ### Fixed
 - Pass `Authorization` header to BloomRemit

--- a/lib/bloom_remit_client.rb
+++ b/lib/bloom_remit_client.rb
@@ -51,7 +51,10 @@ module BloomRemitClient
         "Authorization" => "Basic #{token}"
       },
       channels: {
-        TXN_UPDATES_CHANNEL => { processor: configuration.on_txn_update },
+        TXN_UPDATES_CHANNEL => { 
+          processor: configuration.on_txn_update,
+          message_id: 0,
+        },
       }
     })
   end

--- a/spec/lib/bloom_remit_client_spec.rb
+++ b/spec/lib/bloom_remit_client_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BloomRemitClient do
         expect(subscription[:headers]["Authorization"])
           .to eq "Basic #{encoded_string}"
         expect(subscription[:channels][described_class::TXN_UPDATES_CHANNEL]).
-          to eq({processor: "Processor"})
+          to eq({message_id: 0, processor: "Processor"})
       end
     end
   end


### PR DESCRIPTION
Pass `message_id` of 0. Until long-polling is implemented, MessageBusClientWorker will not end up picking up any messages because a default of `-1` is used by MCBW.